### PR TITLE
Fix tailwind.config.js content path

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,16 +1,13 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: 'class',
-  content: [
-    "./src/**/*.{html,js}",
-    "*.{html,js}"
-  ],
+  darkMode: "class",
+  content: ["./**/*.{html,js}", "*.{html,js}"],
   theme: {
     extend: {},
   },
   plugins: [
-    require('tailwindcss'),
-    require('flowbite/plugin'),
+    require("tailwindcss"),
+    require("flowbite/plugin"),
     require("daisyui"),
   ],
-}
+};


### PR DESCRIPTION
The content path is wrong due to there is no src/ folder in the project, and it caused daisyui classes is not available.